### PR TITLE
Now syntax highlighting works on .usda files too

### DIFF
--- a/Notepad++/install/userDefined_PIXAR_USD.xml
+++ b/Notepad++/install/userDefined_PIXAR_USD.xml
@@ -1,5 +1,5 @@
 <NotepadPlus>
-    <UserLang name="PIXAR USD" ext="usd" udlVersion="2.1">
+    <UserLang name="PIXAR USD" ext="usd usda" udlVersion="2.1">
         <Settings>
             <Global caseIgnored="no" allowFoldOfComments="yes" foldCompact="no" forcePureLC="0" decimalSeparator="0" />
             <Prefix Keywords1="no" Keywords2="no" Keywords3="yes" Keywords4="no" Keywords5="no" Keywords6="no" Keywords7="no" Keywords8="no" />


### PR DESCRIPTION
Fix for https://github.com/AndrewHazelden/PIXAR-USD-Syntax-Highlighter/issues/1